### PR TITLE
Modified toml file for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,23 @@
 name = "multitimer-tui"
 version = "0.1.0"
 edition = "2021"
+readme = "README.md"
+description = """
+multitimer-tui is a productivity tool that lets you attach timers to a To-Do List with a TUI
+"""
+homepage = "https://github.com/Jo6a/multitimer-tui"
+repository = "https://github.com/Jo6a/multitimer-tui"
+license = "MIT"
+keywords = ["tui", "terminal", "timer", "pomodoro", "budget", "terminal-app"]
+categories = ["command-line-utilities"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "multitimer-tui"
+path = "src/main.rs"
+test = false
+bench = false
 
 [dependencies]
 tui = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ multitimer-tui is a productivity tool that lets you attach timers to a To-Do Lis
 homepage = "https://github.com/Jo6a/multitimer-tui"
 repository = "https://github.com/Jo6a/multitimer-tui"
 license = "MIT"
-keywords = ["tui", "terminal", "timer", "pomodoro", "budget", "terminal-app"]
+keywords = ["tui", "terminal", "timer", "pomodoro", "terminal-app"]
 categories = ["command-line-utilities"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Added the mandatory fields to the `cargo.toml` file for publishing to crates.io. Let me know if you want to change the description, keyword, binary name, etc. 

- Logging in to cargo
- Publishing to cargo

These need to be done from the owner's side. [More info](https://doc.rust-lang.org/cargo/reference/publishing.html). Let me know what you think!