### PR TITLE
Added loading bar on active timers

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -139,34 +139,6 @@ impl<'a> Configuration<'a> {
         }
     }
 
-    pub fn write_table_entry(&mut self, c: char) {
-        match self.state.selected().unwrap() {
-            0 => self.darkmode_str.push(c),
-            1 => self.activecolor_str.push(c),
-            2 => self.reverseadding_str.push(c),
-            3 => self.move_finished_timer_str.push(c),
-            4 => self.action_timeout_str.push(c),
-            5 => self.pomodoro_time_table_str.push(c),
-            6 => self.pomodoro_smallbreak_table_str.push(c),
-            7 => self.pomodoro_bigbreak_table_str.push(c),
-            _ => {}
-        }
-    }
-
-    pub fn pop_table_entry(&mut self) -> Option<char> {
-        match self.state.selected().unwrap() {
-            0 => self.darkmode_str.pop(),
-            1 => self.activecolor_str.pop(),
-            2 => self.reverseadding_str.pop(),
-            3 => self.move_finished_timer_str.pop(),
-            4 => self.action_timeout_str.pop(),
-            5 => self.pomodoro_time_table_str.pop(),
-            6 => self.pomodoro_smallbreak_table_str.pop(),
-            7 => self.pomodoro_bigbreak_table_str.pop(),
-            _ => " ".to_string().pop(),
-        }
-    }
-
     pub fn save_table_changes(&mut self) {
         self.darkmode = if self.darkmode_str.is_empty() {
             self.darkmode_str = "false".to_string();

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -10,6 +10,7 @@ pub struct Timer {
     pub is_active: bool,
     pub left_view: bool,
     pub description: String,
+    pub initial_time: u16,
     pub timeleft_secs: u16,
     #[serde(skip_serializing, skip_deserializing)]
     pub endtime: DateTime<Local>,
@@ -24,6 +25,7 @@ impl Timer {
             is_active: false,
             left_view,
             description,
+            initial_time: timeleft_secs,
             timeleft_secs,
             endtime: Local::now(),
             action_info: "   ".to_string(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,7 +7,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Tabs, Wrap},
+    widgets::{Block, Borders, Cell, Clear, Gauge, Paragraph, Row, Table, Tabs, Wrap},
     Frame,
 };
 use std::io;
@@ -89,13 +89,44 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
 
     let len_right_view_timers = config.num_rightview_timers();
     let len_left_view_timers = config.timers.len() - len_right_view_timers;
+
     let left_view_timers: Vec<&Timer> = config.timers.iter().filter(|t| t.left_view).collect();
     let right_view_timers: Vec<&Timer> = config.timers.iter().filter(|t| !t.left_view).collect();
+
+    let mut left_timer_gauge_value = Vec::new();
+    let mut right_timer_gauge_value = Vec::new();
+
+    for i in &left_view_timers {
+        let total_time = i.initial_time as i64;
+        let remaining_time = i.timeleft_secs as i64;
+
+        let completed_time = total_time - remaining_time;
+
+        let percentage_completed = (completed_time as f64 / total_time as f64) * 100.0;
+
+        left_timer_gauge_value.push(percentage_completed)
+        
+    }
+
+    for i in &right_view_timers {
+        let total_time = i.initial_time as i64;
+        let remaining_time = i.timeleft_secs as i64;
+
+        let completed_time = total_time - remaining_time;
+
+        let percentage_completed = (completed_time as f64 / total_time as f64) * 100.0;
+
+        right_timer_gauge_value.push(percentage_completed)
+    }
+
     let mut constraints_vec = Vec::new();
     let mut constraints_vec2 = Vec::new();
+
+    // 1 length constraint for the upper Tab text
     constraints_vec.push(Constraint::Length(1));
+
     for _ in 0..len_left_view_timers {
-        constraints_vec.push(Constraint::Length(3));
+        constraints_vec.push(Constraint::Length(4));
     }
     // Constraints to control all the empty spaces below the timer and the input field.
     // Min 0 so if no space, it won't have any size
@@ -106,7 +137,7 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
     if len_right_view_timers > 0 {
         constraints_vec2.push(Constraint::Length(1));
         for _ in 0..len_right_view_timers {
-            constraints_vec2.push(Constraint::Length(3));
+            constraints_vec2.push(Constraint::Length(4));
         }
         // Constraints to control all the empty spaces below the timer2 and the input field.
         // Min 0 so if no space, it won't have any size
@@ -185,7 +216,7 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
         // len -2 because last 2 are used for rendering the empty fields and the input field
         for i in 1..chunks.len() - 2 {
             let paragraph = Paragraph::new(left_view_timers[i - 1].formatted())
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT))
                 .style(
                     Style::default()
                         .fg(if left_view_timers[i - 1].is_active {
@@ -197,7 +228,46 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
                         })
                         .bg(get_background_color(config.darkmode)),
                 );
-            f.render_widget(paragraph, chunks[i]);
+
+            let timer_label = format!("{:.2}%", left_timer_gauge_value[i - 1]);
+
+            let timer_gauge = Gauge::default()
+                .block(
+                    Block::default()
+                        .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
+                        .border_style(
+                            Style::default()
+                                .fg(if left_view_timers[i - 1].is_active {
+                                    AcceptedColors::from_str(&config.activecolor)
+                                        .unwrap()
+                                        .to_color()
+                                } else {
+                                    Color::DarkGray
+                                })
+                                .bg(get_background_color(config.darkmode)),
+                        ),
+                )
+                .gauge_style(
+                    Style::default()
+                        .fg(if left_view_timers[i - 1].is_active {
+                            AcceptedColors::from_str(&config.activecolor)
+                                .unwrap()
+                                .to_color()
+                        } else {
+                            Color::DarkGray
+                        })
+                        .bg(get_background_color(config.darkmode))
+                        .add_modifier(Modifier::ITALIC),
+                )
+                .label(timer_label).ratio(left_timer_gauge_value[i - 1] / 100.0 as f64).use_unicode(true);
+
+            let divided_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(chunks[i]);
+
+            f.render_widget(paragraph, divided_chunks[0]);
+            f.render_widget(timer_gauge, divided_chunks[1]);
         }
 
         // Renders the empty spaces below the timer with nothing
@@ -220,6 +290,7 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
             input_field,
             &chunks,
             config,
+            right_timer_gauge_value,
             size,
         );
     } else if config.index == 1 {
@@ -235,6 +306,7 @@ pub fn timertab_rendering<B: Backend>(
     input_field: &InputField,
     chunks: &Vec<Rect>,
     config: &Configuration,
+    right_timer_gauge_value: Vec<f64>,
     size: Rect,
 ) {
     if len_right_view_timers > 0 {
@@ -242,7 +314,7 @@ pub fn timertab_rendering<B: Backend>(
         // len -2 because last 2 are used for rendering the empty fields and the input field
         for i in 1..chunks2.len() - 2 {
             let paragraph = Paragraph::new(right_view_timers[i - 1].formatted())
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT))
                 .style(
                     Style::default()
                         .fg(if right_view_timers[i - 1].is_active {
@@ -254,7 +326,44 @@ pub fn timertab_rendering<B: Backend>(
                         })
                         .bg(get_background_color(config.darkmode)),
                 );
-            f.render_widget(paragraph, chunks2[i]);
+                let timer_label = format!("{:.2}%", right_timer_gauge_value[i - 1]);
+                let timer_gauge = Gauge::default()
+                .block(
+                    Block::default()
+                        .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
+                        .border_style(
+                            Style::default()
+                                .fg(if right_view_timers[i - 1].is_active {
+                                    AcceptedColors::from_str(&config.activecolor)
+                                        .unwrap()
+                                        .to_color()
+                                } else {
+                                    Color::DarkGray
+                                })
+                                .bg(get_background_color(config.darkmode)),
+                        ),
+                )
+                .gauge_style(
+                    Style::default()
+                        .fg(if right_view_timers[i - 1].is_active {
+                            AcceptedColors::from_str(&config.activecolor)
+                                .unwrap()
+                                .to_color()
+                        } else {
+                            Color::DarkGray
+                        })
+                        .bg(get_background_color(config.darkmode))
+                        .add_modifier(Modifier::ITALIC),
+                )
+                .label(timer_label).ratio(right_timer_gauge_value[i - 1] / 100.0 as f64).use_unicode(true);
+
+            let divided_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(chunks2[i]);
+
+            f.render_widget(paragraph, divided_chunks[0]);
+            f.render_widget(timer_gauge, divided_chunks[1]);
         }
         // Renders the empty spaces below the timer with nothing
         f.render_widget(Paragraph::new(""), chunks2[chunks2.len() - 2]);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -65,9 +65,6 @@ pub fn handle_key_press(
             KeyCode::Tab => config.next(),
             KeyCode::Esc => config.clear_table_entry(),
             KeyCode::Enter => config.save_table_changes(),
-            KeyCode::Backspace => {
-                config.pop_table_entry();
-            }
             KeyCode::Up => config.previous_table_entry(),
             KeyCode::Down => config.next_table_entry(),
             KeyCode::Right => config.move_value_right(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -105,6 +105,7 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
             constraints_vec.push(Constraint::Length(3));
         }
 
+        // find the % of elapsed time and push them to vec
         let total_time = i.initial_time as i64;
         let remaining_time = i.timeleft_secs as i64;
 
@@ -131,6 +132,7 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
                 constraints_vec2.push(Constraint::Length(3));
             }
 
+            // find the % of elapsed time and push them to vec
             let total_time = i.initial_time as i64;
             let remaining_time = i.timeleft_secs as i64;
 
@@ -230,10 +232,13 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
                         .bg(get_background_color(config.darkmode)),
                 );
 
+            // if the timer is not active, only render the text on the entire chunk
+            // otherwise divide the chunk into 2 smaller chunks and render text + gauge
             if !left_view_timers[i - 1].is_active {
                 f.render_widget(paragraph, chunks[i]);
             } else {
-                paragraph = paragraph.block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT));
+                paragraph = paragraph
+                    .block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT));
                 let gauge_label = format!("{:.2}%", left_timer_gauge_value[i - 1]);
                 let timer_gauge = Gauge::default()
                     .block(
@@ -264,7 +269,7 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
                             .add_modifier(Modifier::ITALIC),
                     )
                     .label(gauge_label)
-                    .ratio(left_timer_gauge_value[i - 1] / 100.0 as f64)
+                    .ratio(left_timer_gauge_value[i - 1] / 100.0)
                     .use_unicode(true);
 
                 let divided_chunks = Layout::default()
@@ -334,10 +339,13 @@ pub fn timertab_rendering<B: Backend>(
                         .bg(get_background_color(config.darkmode)),
                 );
 
+            // if the timer is not active, only render the text on the entire chunk
+            // otherwise divide the chunk into 2 smaller chunks and render text + gauge
             if !right_view_timers[i - 1].is_active {
                 f.render_widget(paragraph, chunks2[i]);
             } else {
-                paragraph = paragraph.block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT));
+                paragraph = paragraph
+                    .block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT));
                 let gauge_label = format!("{:.2}%", right_timer_gauge_value[i - 1]);
                 let timer_gauge = Gauge::default()
                     .block(
@@ -368,7 +376,7 @@ pub fn timertab_rendering<B: Backend>(
                             .add_modifier(Modifier::ITALIC),
                     )
                     .label(gauge_label)
-                    .ratio(right_timer_gauge_value[i - 1] / 100.0 as f64)
+                    .ratio(right_timer_gauge_value[i - 1] / 100.0)
                     .use_unicode(true);
 
                 let divided_chunks = Layout::default()


### PR DESCRIPTION
**What changed:**
- Config file now saves an additional value `initial_time` to calculate elapsed time for the loading bar
- All active timers now show a loading bar
- Some unused functions were removed

Resolves #8. @Jo6a let me know what you think of it and if you have any further suggestions. 