### PR TITLE
Modifed add commands to take color input

### DIFF
--- a/helptext.txt
+++ b/helptext.txt
@@ -1,8 +1,8 @@
 Commands                        Description
-add [HH:MM:SS] [description]    adds a timer to the left column with the given time and description.
-add [minutes] [description]     adds a timer to the left column with the given minutes and description.
-add2 [minutes] [description]    adds a timer to the right column with the given minutes and description.
-addr [minutes] [description]    adds a timer to the left column in reverse order with the given minutes and description.
+add [HH:MM:SS] [type(optional)] [description]    adds a timer to the left column with the given time and description.
+add [minutes] [type(optional)]  [description]    adds a timer to the left column with the given minutes and description.
+add2 [minutes] [type(optional)] [description]    adds a timer to the right column with the given minutes and description.
+addr [minutes] [type(optional)] [description]    adds a timer to the left column in reverse order with the given minutes and description.
 addp                            adds a pair of Pomodoro timers to the left column with the durations specified in the Config tab.
 rm [id]                         removes the timer with the given id.
 clear                           removes all timers.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -16,10 +16,16 @@ pub struct Timer {
     pub endtime: DateTime<Local>,
     #[serde(skip_serializing, skip_deserializing)]
     pub action_info: String,
+    pub timer_type: Option<String>,
 }
 
 impl Timer {
-    pub fn new(description: String, timeleft_secs: u64, left_view: bool) -> Self {
+    pub fn new(
+        description: String,
+        timeleft_secs: u64,
+        left_view: bool,
+        timer_type: Option<String>,
+    ) -> Self {
         Self {
             id: 0,
             is_active: false,
@@ -29,6 +35,7 @@ impl Timer {
             timeleft_secs,
             endtime: Local::now(),
             action_info: "   ".to_string(),
+            timer_type,
         }
     }
 

--- a/src/timer_logic.rs
+++ b/src/timer_logic.rs
@@ -7,8 +7,9 @@ pub fn add_timer(
     routine: &str,
     config: &mut Configuration,
     reverse_adding: bool,
+    color_input: Option<String>,
 ) {
-    let timer = config.create_timer_for_input(argument1, argument2, routine != "add2");
+    let timer = config.create_timer_for_input(argument1, argument2, routine != "add2", color_input);
     config.add_timer_to_config(timer, reverse_adding);
 }
 
@@ -17,6 +18,7 @@ pub fn add_pomodoro_timer(config: &mut Configuration) {
         "Pomodoro-Timer".to_string(),
         config.pomodoro_time * 60,
         true,
+        Some(config.timer_colors["Focus"].to_owned()),
     );
     let timer2 = Timer::new(
         "Pomodoro-Break".to_string(),
@@ -26,6 +28,7 @@ pub fn add_pomodoro_timer(config: &mut Configuration) {
             config.pomodoro_smallbreak * 60
         },
         true,
+        Some(config.timer_colors["Break"].to_owned()),
     );
 
     config.add_timer_to_config(timer1, false);
@@ -154,17 +157,43 @@ pub fn parse_input(input: &str, config: &mut Configuration) {
     if input.is_empty() {
         return;
     }
+
     let mut parts = input.split_whitespace();
     let routine = parts.next().unwrap_or("");
     let argument1 = parts.next().unwrap_or("").to_string();
-    let mut argument2: String = parts.collect::<Vec<&str>>().join(" ");
+    let mut collected_argument2 = parts.collect::<Vec<&str>>();
+
+    // check if the 3rd argument is a valid color
+    let color_input = if collected_argument2.len() > 0 && config.timer_colors.contains_key(&collected_argument2[0].to_lowercase()) {
+        let color = Some(config.timer_colors[&collected_argument2[0].to_lowercase()].to_owned());
+        collected_argument2.remove(0);
+        color
+    } else {
+        None
+    };
+
+    let mut argument2 = collected_argument2.join(" ");
 
     match routine {
         "a" | "add" | "add2" => {
-            add_timer(&argument1, &mut argument2, routine, config, false);
+            add_timer(
+                &argument1,
+                &mut argument2,
+                routine,
+                config,
+                false,
+                color_input,
+            );
         }
         "ar" | "addr" => {
-            add_timer(&argument1, &mut argument2, routine, config, true);
+            add_timer(
+                &argument1,
+                &mut argument2,
+                routine,
+                config,
+                true,
+                color_input,
+            );
         }
         "addp" => {
             add_pomodoro_timer(config);

--- a/src/timer_logic.rs
+++ b/src/timer_logic.rs
@@ -18,7 +18,7 @@ pub fn add_pomodoro_timer(config: &mut Configuration) {
         "Pomodoro-Timer".to_string(),
         config.pomodoro_time * 60,
         true,
-        Some(config.timer_colors["Focus"].to_owned()),
+        Some(config.timer_colors["focus"].to_owned()),
     );
     let timer2 = Timer::new(
         "Pomodoro-Break".to_string(),
@@ -28,7 +28,7 @@ pub fn add_pomodoro_timer(config: &mut Configuration) {
             config.pomodoro_smallbreak * 60
         },
         true,
-        Some(config.timer_colors["Break"].to_owned()),
+        Some(config.timer_colors["break"].to_owned()),
     );
 
     config.add_timer_to_config(timer1, false);
@@ -164,8 +164,13 @@ pub fn parse_input(input: &str, config: &mut Configuration) {
     let mut collected_argument2 = parts.collect::<Vec<&str>>();
 
     // check if the 3rd argument is a valid color
-    let color_input = if collected_argument2.len() > 0 && config.timer_colors.contains_key(&collected_argument2[0].to_lowercase()) {
+    let color_input = if collected_argument2.len() > 0
+        && config
+            .timer_colors
+            .contains_key(&collected_argument2[0].to_lowercase())
+    {
         let color = Some(config.timer_colors[&collected_argument2[0].to_lowercase()].to_owned());
+        // remove the color argument from the input
         collected_argument2.remove(0);
         color
     } else {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -218,23 +218,32 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
         // loop for timers
         // len -2 because last 2 are used for rendering the empty fields and the input field
         for i in 1..chunks.len() - 2 {
-            let mut paragraph = Paragraph::new(left_view_timers[i - 1].formatted())
+            let current_timer = left_view_timers[i - 1];
+
+            let current_timer_color =
+                if current_timer.timer_type.is_some() && current_timer.is_active {
+                    AcceptedColors::from_str(current_timer.timer_type.as_ref().unwrap())
+                        .unwrap()
+                        .to_color()
+                } else if current_timer.is_active {
+                    AcceptedColors::from_str(&config.activecolor)
+                        .unwrap()
+                        .to_color()
+                } else {
+                    Color::DarkGray
+                };
+
+            let mut paragraph = Paragraph::new(current_timer.formatted())
                 .block(Block::default().borders(Borders::ALL))
                 .style(
                     Style::default()
-                        .fg(if left_view_timers[i - 1].is_active {
-                            AcceptedColors::from_str(&config.activecolor)
-                                .unwrap()
-                                .to_color()
-                        } else {
-                            Color::DarkGray
-                        })
+                        .fg(current_timer_color)
                         .bg(get_background_color(config.darkmode)),
                 );
 
             // if the timer is not active, only render the text on the entire chunk
             // otherwise divide the chunk into 2 smaller chunks and render text + gauge
-            if !left_view_timers[i - 1].is_active {
+            if !current_timer.is_active {
                 f.render_widget(paragraph, chunks[i]);
             } else {
                 paragraph = paragraph
@@ -246,25 +255,13 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, config: &mut Configuration, input_field:
                             .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
                             .border_style(
                                 Style::default()
-                                    .fg(if left_view_timers[i - 1].is_active {
-                                        AcceptedColors::from_str(&config.activecolor)
-                                            .unwrap()
-                                            .to_color()
-                                    } else {
-                                        Color::DarkGray
-                                    })
+                                    .fg(current_timer_color)
                                     .bg(get_background_color(config.darkmode)),
                             ),
                     )
                     .gauge_style(
                         Style::default()
-                            .fg(if left_view_timers[i - 1].is_active {
-                                AcceptedColors::from_str(&config.activecolor)
-                                    .unwrap()
-                                    .to_color()
-                            } else {
-                                Color::DarkGray
-                            })
+                            .fg(current_timer_color)
                             .bg(get_background_color(config.darkmode))
                             .add_modifier(Modifier::ITALIC),
                     )
@@ -325,23 +322,31 @@ pub fn timertab_rendering<B: Backend>(
         // loop for timers2
         // len -2 because last 2 are used for rendering the empty fields and the input field
         for i in 1..chunks2.len() - 2 {
-            let mut paragraph = Paragraph::new(right_view_timers[i - 1].formatted())
+            let current_timer = right_view_timers[i - 1];
+            let current_timer_color =
+                if current_timer.timer_type.is_some() && current_timer.is_active {
+                    AcceptedColors::from_str(current_timer.timer_type.as_ref().unwrap())
+                        .unwrap()
+                        .to_color()
+                } else if current_timer.is_active {
+                    AcceptedColors::from_str(&config.activecolor)
+                        .unwrap()
+                        .to_color()
+                } else {
+                    Color::DarkGray
+                };
+
+            let mut paragraph = Paragraph::new(current_timer.formatted())
                 .block(Block::default().borders(Borders::ALL))
                 .style(
                     Style::default()
-                        .fg(if right_view_timers[i - 1].is_active {
-                            AcceptedColors::from_str(&config.activecolor)
-                                .unwrap()
-                                .to_color()
-                        } else {
-                            Color::DarkGray
-                        })
+                        .fg(current_timer_color)
                         .bg(get_background_color(config.darkmode)),
                 );
 
             // if the timer is not active, only render the text on the entire chunk
             // otherwise divide the chunk into 2 smaller chunks and render text + gauge
-            if !right_view_timers[i - 1].is_active {
+            if !current_timer.is_active {
                 f.render_widget(paragraph, chunks2[i]);
             } else {
                 paragraph = paragraph
@@ -353,25 +358,13 @@ pub fn timertab_rendering<B: Backend>(
                             .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
                             .border_style(
                                 Style::default()
-                                    .fg(if right_view_timers[i - 1].is_active {
-                                        AcceptedColors::from_str(&config.activecolor)
-                                            .unwrap()
-                                            .to_color()
-                                    } else {
-                                        Color::DarkGray
-                                    })
+                                    .fg(current_timer_color)
                                     .bg(get_background_color(config.darkmode)),
                             ),
                     )
                     .gauge_style(
                         Style::default()
-                            .fg(if right_view_timers[i - 1].is_active {
-                                AcceptedColors::from_str(&config.activecolor)
-                                    .unwrap()
-                                    .to_color()
-                            } else {
-                                Color::DarkGray
-                            })
+                            .fg(current_timer_color)
                             .bg(get_background_color(config.darkmode))
                             .add_modifier(Modifier::ITALIC),
                     )
@@ -491,6 +484,38 @@ pub fn configtab_rendering<B: Backend>(
         vec![
             "Pomodoro Big Break Time".to_string(),
             config.pomodoro_bigbreak_table_str.to_owned(),
+        ],
+        vec![
+            "Urgent Color".to_string(),
+            config.timer_colors["urgent"].to_owned(),
+        ],
+        vec![
+            "Important Color".to_string(),
+            config.timer_colors["important"].to_owned(),
+        ],
+        vec![
+            "Focus Color".to_string(),
+            config.timer_colors["focus"].to_owned(),
+        ],
+        vec![
+            "Break Color".to_string(),
+            config.timer_colors["break"].to_owned(),
+        ],
+        vec![
+            "Study Color".to_string(),
+            config.timer_colors["study"].to_owned(),
+        ],
+        vec![
+            "Coding Color".to_string(),
+            config.timer_colors["coding"].to_owned(),
+        ],
+        vec![
+            "Casual Color".to_string(),
+            config.timer_colors["casual"].to_owned(),
+        ],
+        vec![
+            "Fun Color".to_string(),
+            config.timer_colors["fun"].to_owned(),
         ],
     ];
     let rows = items.iter().map(|item| {

--- a/src/ui_states.rs
+++ b/src/ui_states.rs
@@ -24,6 +24,14 @@ pub enum ConfigType {
     PomodoroTime,
     PomodoroSmallBreak,
     PomodoroBigBreak,
+    UrgentColor,
+    ImportantColor,
+    FocusColor,
+    BreakColor,
+    StudyColor,
+    CodingColor,
+    CasualColor,
+    FunColor,
 }
 
 impl Default for ConfigType {
@@ -42,13 +50,21 @@ impl ConfigType {
             ConfigType::ActionAfterTimer => ConfigType::PomodoroTime,
             ConfigType::PomodoroTime => ConfigType::PomodoroSmallBreak,
             ConfigType::PomodoroSmallBreak => ConfigType::PomodoroBigBreak,
-            ConfigType::PomodoroBigBreak => ConfigType::DarkMode,
+            ConfigType::PomodoroBigBreak => ConfigType::UrgentColor,
+            ConfigType::UrgentColor => ConfigType::ImportantColor,
+            ConfigType::ImportantColor => ConfigType::FocusColor,
+            ConfigType::FocusColor => ConfigType::BreakColor,
+            ConfigType::BreakColor => ConfigType::StudyColor,
+            ConfigType::StudyColor => ConfigType::CodingColor,
+            ConfigType::CodingColor => ConfigType::CasualColor,
+            ConfigType::CasualColor => ConfigType::FunColor,
+            ConfigType::FunColor => ConfigType::DarkMode,
         };
     }
 
     pub fn previous(&mut self) {
         *self = match self {
-            ConfigType::DarkMode => ConfigType::PomodoroBigBreak,
+            ConfigType::DarkMode => ConfigType::FunColor,
             ConfigType::ActiveColor => ConfigType::DarkMode,
             ConfigType::ReverseAddingTimer => ConfigType::ActiveColor,
             ConfigType::MoveFinishedTimer => ConfigType::ReverseAddingTimer,
@@ -56,6 +72,30 @@ impl ConfigType {
             ConfigType::PomodoroTime => ConfigType::ActionAfterTimer,
             ConfigType::PomodoroSmallBreak => ConfigType::PomodoroTime,
             ConfigType::PomodoroBigBreak => ConfigType::PomodoroSmallBreak,
+            ConfigType::UrgentColor => ConfigType::PomodoroBigBreak,
+            ConfigType::ImportantColor => ConfigType::UrgentColor,
+            ConfigType::FocusColor => ConfigType::ImportantColor,
+            ConfigType::BreakColor => ConfigType::FocusColor,
+            ConfigType::StudyColor => ConfigType::BreakColor,
+            ConfigType::CodingColor => ConfigType::StudyColor,
+            ConfigType::CasualColor => ConfigType::CodingColor,
+            ConfigType::FunColor => ConfigType::CasualColor,
+        }
+    }
+}
+
+impl fmt::Display for ConfigType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigType::UrgentColor => write!(f, "urgent"),
+            ConfigType::ImportantColor => write!(f, "important"),
+            ConfigType::FocusColor => write!(f, "focus"),
+            ConfigType::BreakColor => write!(f, "break"),
+            ConfigType::StudyColor => write!(f, "study"),
+            ConfigType::CodingColor => write!(f, "coding"),
+            ConfigType::CasualColor => write!(f, "casual"),
+            ConfigType::FunColor => write!(f, "fun"),
+            _ => write!(f, ""),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,21 @@
+use std::collections::HashMap;
+
 pub fn reverse_bool(input: &str) -> String {
     let value = input.parse::<bool>().unwrap_or(false);
     (!value).to_string()
+}
+
+/// Default timer types and their colors
+pub fn get_initial_timer_colors() -> HashMap<String, String> {
+    HashMap::from([
+        ("urgent".to_string(), "Red".to_string()),
+        ("important".to_string(), "Blue".to_string()),
+        ("casual".to_string(), "Green".to_string()),
+        ("break".to_string(), "Yellow".to_string()),
+        ("focus".to_string(), "Magenta".to_string()),
+        ("fun".to_string(), "LightMagenta".to_string()),
+        ("study".to_string(), "LightCyan".to_string()),
+        ("deadline".to_string(), "LightRed".to_string()),
+        ("coding".to_string(), "LightGreen".to_string()),
+    ])
 }


### PR DESCRIPTION
**What Changed:**
- Commands related to `add` now takes an optional `type` argument
- Added 9 pre-set timer types + modifiable from the config page
- Updated help text
- Pomodoro timer command now sets focus and break timer type respectively
- Reduced some code repetition on UI 

Additional timer types can also be added directly to the JSON file and will be recognized but it won't be visible on the config page and the feature is not communicated anywhere yet. 

Let me know if you want to change anything! Resolves #10 

